### PR TITLE
Add travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: php
+sudo: false
+
+php:
+  - 7.0
+  - 7.1
+  - 7.2
+  - nightly
+
+matrix:
+  allow_failures:
+    - php: nightly
+
+before_install:
+  - composer install
+
+script:
+  - composer cs-fix
+  - composer test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ matrix:
     - php: nightly
 
 before_install:
-  - composer install
+  - composer install -n
+  - composer cs-fix
 
 script:
-  - composer cs-fix
   - composer test

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ matrix:
 
 before_install:
   - composer install -n
-  - composer cs-fix
 
 script:
   - composer test

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         }
     ],
     "require": {
-        "php": "^7.0"
+        "php": "^7.0",
+        "ext-mbstring": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -14,4 +14,9 @@
 			<directory>tests</directory>
 		</testsuite>
 	</testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">src</directory>
+        </whitelist>
+    </filter>
 </phpunit>


### PR DESCRIPTION
# Changed log
- Integrate the Travis build.
- add the ```ext-mbstring``` to check whether this is installed during executing ```composer install``` command.
- Add the ```composer cs-fix``` script.
- Use the filter white list in ```phpunit.xml``` setting.